### PR TITLE
Added layout and page for All posts

### DIFF
--- a/_layouts/allposts.html
+++ b/_layouts/allposts.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<!--
+	Forty by HTML5 UP
+	html5up.net | @ajlkn
+	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
+-->
+<html>
+
+{% include head.html %}
+
+<body>
+
+    {% include header.html %} 
+    
+    
+<!-- Main -->
+<div id="main" class="alt">
+
+<!-- One -->
+<section id="one">
+	<div class="inner">
+                {% for post in site.posts %}
+		<header class="major">
+			<h1>{{ post.title }}</h1>
+		</header>
+		{% if post.image %}<span class="image main"><img src="{{ site.baseurl }}/{{ post.image }}" alt="" /></span>{% endif %}
+		<p>{{ post.date }}</p>
+		<p>{{ post.content }}</p>
+                {% endfor %}
+	</div>
+</section>
+
+</div>
+
+    {% include footer.html %}
+
+</body>
+
+</html>

--- a/all_posts.md
+++ b/all_posts.md
@@ -1,0 +1,10 @@
+---
+layout: allposts
+title: All posts
+landing-title: 'All posts'
+description: null
+image: null
+author: null
+---
+
+<h1>All posts</h1>


### PR DESCRIPTION
Simple approach to making All Posts available. This adds a layout that accumulates all posts and a page listed in the menu that displays them. It is pretty basic and there is no search or summary by month, and no pagination, etc.