### PR TITLE
abstract form endpoint URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,6 +17,9 @@ phone: (716) 555-5555
 tiles-source: posts # accepts "posts" or "pages"
 tiles-count: 6
 
+# contact form settings
+form_url: https://formcarry.com/s/XXXXXX # endpoint URL to receive contact form submissions
+
 # social settings
 500px_url:
 facebook_url:

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,14 +2,14 @@
 <section id="contact">
 	<div class="inner">
 		<section>
-			<form action="https://formspree.io/{{ site.email }}" method="POST">
+			<form action="{{ site.form_url }}" method="POST">
 				<div class="field half first">
 					<label for="name">Name</label>
 					<input type="text" name="name" id="name" />
 				</div>
 				<div class="field half">
 					<label for="email">Email</label>
-					<input type="text" name="_replyto" id="email" />
+					<input type="text" name="email" id="email" />
 				</div>
 				<div class="field">
 					<label for="message">Message</label>


### PR DESCRIPTION
This creates a new field in _config.yml to ask for the form endpoint URL, rather than assuming the use of Formspree.io. This is motivated by Formspree's requirement that the contact form on each page URL must be separately verified by the site owner, which seems to make it undesirable as a default contact form service for this particular theme.

I also proposed renaming the Formspree-specific "_replyto" field to the more generic name "email". 

I think this approach would guide users to sign up for their choice of contact form service at the outset, rather than leading them to use a service that doesn't quite meet the needs of this theme.

Cheers,
Daniel