### PR TITLE
remove deprecation warning

### DIFF
--- a/_sass/libs/_skel.scss
+++ b/_sass/libs/_skel.scss
@@ -4,6 +4,7 @@
 
 	/// Breakpoints.
 	/// @var {list}
+	$breakpoints: null;
 	$breakpoints: () !global;
 
 	/// Vendor prefixes.


### PR DESCRIPTION
add "$breakpoints: null;" at the beginning of _sass/libs/_skel.scss to remove deprecation warning