### PR TITLE
fix a typo that prevented landing.html's main image from showing

### DIFF
--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -15,7 +15,7 @@
         <section id="banner" class="style2">
             <div class="inner">
                 <span class="image">
-                    <img src="{{ site.baseurl }}/{{ page.image }}" alt="">
+                    <img src="{{ site.baseurl }}{{ page.image }}" alt="">
                 </span>
                 <header class="major">
 


### PR DESCRIPTION
The main image in the banner behind the title wasn't shown properly as {{ site.baseurl }} already include an ending /. This lead to URLs of the form `www.sitename.sth/**/**assets/...`

The problem isn't completely fixed as now the image is shown with a fixed top-left pixel (i.e. if the image is too big it will show only the top left part). Sadly I don't know CSS and I can't tell the site to horizontally and vertically centre the image. I tried to add a 'vertical-align: middle' in `_sass/components/_image.scss_` but it didn't work. Hope someone can fix this.