### PR TITLE
Remove the "/" remove extra / in url

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,7 +3,7 @@
 
 <!-- Header -->
 <header id="header"{% if page.layout == "landing" %} class="alt style2"{% endif %}{% if page.layout == "home" %} class="alt"{% endif %}>
-	<a href="{{ "" | absolute_url }}/" class="logo"><strong>{{ site.title }}</strong> <span>{{ site.subtitle }}</span></a>
+	<a href="{{ "" | absolute_url }}" class="logo"><strong>{{ site.title }}</strong> <span>{{ site.subtitle }}</span></a>
 	<nav>
 		<a href="#menu">Menu</a>
 	</nav>
@@ -14,7 +14,7 @@
 	<ul class="links">
         {% for page in site.pages %}
 		    {% if page.layout == "home" %}
-		        <li><a href="{{ "" | absolute_url }}/">{{ page.title }}</a></li>
+		        <li><a href="{{ "" | absolute_url }}">{{ page.title }}</a></li>
 	    	{% endif %}
 		{% endfor %}
 		{% for page in site.html_pages %}


### PR DESCRIPTION
I can't replicate it on your demo webite.

Please verify it. 
As I'm getting extra "/" in my address bar if I'm using the header button to navigate in different page.
If this doen't works for you close this pull.

How to reproduce. 

Add a page 

with dummy data and these headers

```
---
layout: (any)
title: (any)
nav-menu: true
description: Example 
image: assets/images/bannerDownload.png
---
```

Now when navigate to home by left top header button. It gives extra / in address bar like this..

`http://example.com//`