### PR TITLE
Add is-loading class earlier to avoid flicker

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -9,6 +9,7 @@
 {% include head.html %}
 
 <body>
+    <script type="text/javascript">document.body.classList.add("is-loading");</script>
 
     {% include header.html %} {{ content }} {% include footer.html %}
 


### PR DESCRIPTION
I couldn't make it work otherwise that the title and logo don't flash white for a couple of hundred milliseconds often