### PR TITLE
Updated main.scss to fix error

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1,5 +1,3 @@
----
----
 @import 'libs/vars';
 @import 'libs/functions';
 @import 'libs/mixins';


### PR DESCRIPTION
Deleted the first two lines that were causing this error:

```
Conversion error: Jekyll::Converters::Scss encountered an error while converting 'assets/css/main.scss':
                    Error: File to import not found or unreadable: libs/vars. on line 1:1 of main.scss >> @import 'libs/vars'; ^
```

After deleting them looks like its fixed.