### PR TITLE
 The formspree.io link to the form no longer work

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Simply fork this repository and start editing the `_config.yml` file!
 
 # Added Features
 
-* **[Formspree.io](https://formspree.io/) contact form integration** - just add your email to the `_config.yml` and it works!
+* **[Formspree.io](https://formspree.io/) contact form integration** - just add your form id code  to the `_config.yml` and it works!
 * Use `_config.yml` to **set whether the homepage tiles should pull pages or posts**, as well as how many to display.
 * Add your **social profiles** easily in `_config.yml`. Only social profiles buttons you enter in `config.yml` show up on the site footer!
 * Set **featured images** in front matter.

--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,7 @@
 title: Forty
 subtitle: by HTML5 UP
 email: youremailaddress@gmail.com
+emailformcode: mjvjlbsnmjvjlbsn # Your form's endpoint code e.g. https://formspree.io/f/mjvjlbsnmjvjlbsn
 description: A responsive site template designed by HTML5 Up<br /> and released under the Creative Commons.
 baseurl: "/forty-jekyll-theme" # the subpath of your site, e.g. /blog
 url: # the base hostname & protocol for your site

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,7 +2,7 @@
 <section id="contact">
 	<div class="inner">
 		<section>
-			<form action="https://formspree.io/{{ site.email }}" method="POST">
+			<form action="https://formspree.io/f/{{ site.emailformcode }}" method="POST">
 				<div class="field half first">
 					<label for="name">Name</label>
 					<input type="text" name="name" id="name" />


### PR DESCRIPTION
 #192
- added separated variable in the _config.yml file
- change  action link in the html form
- changed readme description about the link